### PR TITLE
Modify custom URL regex to support more TLDs

### DIFF
--- a/src/components/NewLink.vue
+++ b/src/components/NewLink.vue
@@ -27,7 +27,7 @@ import { required, url, helpers } from "vuelidate/lib/validators";
 /* eslint-disable */
 const customURL = helpers.regex(
   "customURL",
-  /^(http(s)?:\/\/)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}(:[0-9]*)*\b([-a-zA-Z0-9@:%_\(\)\+.~#?&//=]*)$/
+  /^(http(s)?:\/\/)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,18}(:[0-9]*)*\b([-a-zA-Z0-9@:%_\(\)\+.~#?&//=]*)$/
 );
 /* eslint-enable */
 

--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -18,7 +18,9 @@
                 class="button"
                 target="_blank"
                 :href="
-                  `https://twitter.com/intent/tweet?text=${currentList.description} theurlist.com/${currentList.vanityUrl}`
+                  `https://twitter.com/intent/tweet?text=${
+                    currentList.description
+                  } theurlist.com/${currentList.vanityUrl}`
                 "
               >
                 <span class="icon"><i class="fab fa-twitter"></i></span>
@@ -27,7 +29,9 @@
                 class="button"
                 target="_blank"
                 :href="
-                  `https://www.facebook.com/sharer/sharer.php?u=theurlist.com/${currentList.vanityUrl}`
+                  `https://www.facebook.com/sharer/sharer.php?u=theurlist.com/${
+                    currentList.vanityUrl
+                  }`
                 "
               >
                 <span class="icon"><i class="fab fa-facebook-f"></i></span>
@@ -36,7 +40,9 @@
                 class="button"
                 target="_blank"
                 :href="
-                  `https://www.linkedin.com/shareArticle?mini=true?summary=${currentList.description}&url=https://theurlist.com?${currentList.vanityUrl}`
+                  `https://www.linkedin.com/shareArticle?mini=true?summary=${
+                    currentList.description
+                  }&url=https://theurlist.com?${currentList.vanityUrl}`
                 "
               >
                 <span class="icon"><i class="fab fa-linkedin-in"></i></span>


### PR DESCRIPTION
At the moment, The Urlist doesn't support TLDs longer than 6 characters. I.e. the URLs like https://data-flair.training/blogs/deep-learning-project-ideas/ will not validate. There are a bunch of TLDs that are longer than 6 characters - https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains. 

The PR is to modify the max length of TLD to 18 characters, which should cover most of the cases. The longest one I found on Wikipedia is 18 characters - `.travelersinsurance`. An idea, to make it more future proof, would be to support any length. Something like `[^\:\/]{2,}`.